### PR TITLE
remove primaryDnsServer from params for Set-DeviceConfig

### DIFF
--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/DeviceDetails/SetAzureStorSimpleDevice.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/DeviceDetails/SetAzureStorSimpleDevice.cs
@@ -62,27 +62,19 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
         public TimeZoneInfo TimeZone { get; set; }
 
         /// <summary>
-        /// Primary DNS server for the device.
-        /// </summary>
-        [Parameter(Mandatory = false, Position = 3, HelpMessage = StorSimpleCmdletHelpMessage.PrimaryDnsServer)]
-        [ValidateNotNullOrEmpty]
-        public string PrimaryDnsServer { get; set; }
-        
-        /// <summary>
         /// Secondary DNS server for the device.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 4, HelpMessage = StorSimpleCmdletHelpMessage.SecondaryDnsServer)]
+        [Parameter(Mandatory = false, Position = 3, HelpMessage = StorSimpleCmdletHelpMessage.SecondaryDnsServer)]
         [ValidateNotNullOrEmpty]
         public string SecondaryDnsServer { get; set; }
         
         /// <summary>
         /// A collection of network configs for interfaces on the device.
         /// </summary>
-        [Parameter(Mandatory = false, Position = 5, HelpMessage = StorSimpleCmdletHelpMessage.StorSimpleNetworkConfig)]
+        [Parameter(Mandatory = false, Position = 4, HelpMessage = StorSimpleCmdletHelpMessage.StorSimpleNetworkConfig)]
         [ValidateNotNullOrEmpty]
         public NetworkConfig[] StorSimpleNetworkConfig { get; set; }
 
-        private IPAddress primaryDnsServer;
         private IPAddress secondaryDnsServer;
 
         public override void ExecuteCmdlet()
@@ -107,7 +99,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
 
                 // If the device is being configured for the first time, validate that mandatory params 
                 // for first setup have been provided
-                if (!this.IsDeviceConfigurationCompleteForDevice(deviceDetails) && !ValidParamsForFirstDeviceConfiguration(StorSimpleNetworkConfig, TimeZone,PrimaryDnsServer))
+                if (!deviceDetails.DeviceProperties.IsConfigUpdated && !ValidParamsForFirstDeviceConfiguration(StorSimpleNetworkConfig, TimeZone, SecondaryDnsServer))
                 {
                     WriteVerbose(Resources.MandatoryParamsMissingForInitialDeviceConfiguration);
                     WriteObject(null);
@@ -124,7 +116,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
 
                 // Update device details objects with the details provided to the cmdlet
                 // and make request with updated data
-                var taskStatusInfo = StorSimpleClient.UpdateDeviceDetails(deviceDetails, this.NewName, this.TimeZone, this.primaryDnsServer, this.secondaryDnsServer, this.StorSimpleNetworkConfig);
+                var taskStatusInfo = StorSimpleClient.UpdateDeviceDetails(deviceDetails, this.NewName, this.TimeZone, this.secondaryDnsServer, this.StorSimpleNetworkConfig);
 
                 HandleSyncTaskResponse(taskStatusInfo, "Setup");
                 if (taskStatusInfo.AsyncTaskAggregatedResult == AsyncTaskAggregatedResult.Succeeded)
@@ -154,10 +146,6 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                     return false;
                 }
                 DeviceId = deviceId;
-            }
-            if (!TrySetIPAddress(PrimaryDnsServer, out primaryDnsServer, "PrimaryDnsServer"))
-            {
-                return false;
             }
             if (!TrySetIPAddress(SecondaryDnsServer, out secondaryDnsServer, "SecondaryDnsServer"))
             {

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/ServiceClients/StorSimpleDevicesClient.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/ServiceClients/StorSimpleDevicesClient.cs
@@ -46,15 +46,13 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
         /// <param name="deviceDetails">Current device details for the device.</param>
         /// <param name="newName">New friendly name for the device. Null if its not to be changed</param>
         /// <param name="timeZone">New timeZone value for the device. Null if its not to be changed</param>
-        /// <param name="primaryDnsServer">New primary DNS server address for the device. Null if its not to be changed</param>
         /// <param name="secondaryDnsServer">New Secondary DNS Server address for the device. Null if its not to be changed</param>
         /// <param name="networkConfigs">An array or NetworkConfig objects for different interfaces. Null if its not to be changed</param>
         /// <returns></returns>
-        public TaskStatusInfo UpdateDeviceDetails(DeviceDetails deviceDetails, string newName, TimeZoneInfo timeZone, IPAddress primaryDnsServer,
-            IPAddress secondaryDnsServer, NetworkConfig[] networkConfigs)
+        public TaskStatusInfo UpdateDeviceDetails(DeviceDetails deviceDetails, string newName, TimeZoneInfo timeZone, IPAddress secondaryDnsServer, NetworkConfig[] networkConfigs)
         {
             // Update the object
-            this.UpdateDeviceDetailsObject(deviceDetails, newName, timeZone, primaryDnsServer, secondaryDnsServer, networkConfigs);
+            this.UpdateDeviceDetailsObject(deviceDetails, newName, timeZone, secondaryDnsServer, networkConfigs);
             // Copy stuff over from the DeviceDetails object into a new DeviceDetailsRequest object.
             var request = new DeviceDetailsRequest();
             MiscUtils.CopyProperties(deviceDetails, request);
@@ -153,8 +151,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
         /// Modify the provided DeviceDetails object with the data provided
         /// </summary>
         /// <param name="details"></param>
-        private void UpdateDeviceDetailsObject(DeviceDetails deviceDetails, string newName, TimeZoneInfo timeZone, IPAddress primaryDnsServer, 
-            IPAddress secondaryDnsServer, NetworkConfig[] networkConfigs)
+        private void UpdateDeviceDetailsObject(DeviceDetails deviceDetails, string newName, TimeZoneInfo timeZone, IPAddress secondaryDnsServer, NetworkConfig[] networkConfigs)
         {
             // modify details for non-null data provided to cmdlet
 
@@ -167,19 +164,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
             {
                 deviceDetails.TimeServer.TimeZone = timeZone.StandardName;
             }
-            if (primaryDnsServer != null)
-            {
-                var primaryDnsString = primaryDnsServer.ToString();
-                var primaryDnsType = primaryDnsServer.AddressFamily;
-                if (primaryDnsType == AddressFamily.InterNetwork)   // IPv4
-                {
-                    deviceDetails.DnsServer.PrimaryIPv4 = primaryDnsString;
-                }
-                else if (primaryDnsType == AddressFamily.InterNetworkV6)
-                {
-                    deviceDetails.DnsServer.PrimaryIPv6 = primaryDnsString;
-                }
-            }
+
             if (secondaryDnsServer != null)
             {
                 var secondaryDnsString = secondaryDnsServer.ToString();

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/StorSimpleCmdletBase.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/StorSimpleCmdletBase.cs
@@ -460,7 +460,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
         /// Validate that all mandatory data for the first Device Configuration has been provided.
         /// </summary>
         /// <returns>bool indicating whether all mandatory data is there or not.</returns>
-        internal bool ValidParamsForFirstDeviceConfiguration(NetworkConfig[] netConfigs, TimeZoneInfo timeZone, string primaryDnsServer)
+        internal bool ValidParamsForFirstDeviceConfiguration(NetworkConfig[] netConfigs, TimeZoneInfo timeZone, string secondaryDnsServer)
         {
             if (netConfigs == null)
             {
@@ -468,12 +468,12 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
             }
             // Make sure network config for Data0 has been provided with atleast Controller0 IP Address
             var data0 = netConfigs.FirstOrDefault(x => x.InterfaceAlias == NetInterfaceId.Data0);
-            if (data0 == null || data0.Controller0IPv4Address == null)
+            if (data0 == null || data0.Controller0IPv4Address == null || data0.Controller1IPv4Address == null)
             {
                 return false;
             }
-            // Timezone and Primary Dns Server are also mandatory
-            if (timeZone == null || string.IsNullOrEmpty(primaryDnsServer))
+            // Timezone and Secondary Dns Server are also mandatory
+            if (timeZone == null || string.IsNullOrEmpty(secondaryDnsServer))
             {
                 return false;
             }

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/StorSimpleCmdletHelpMessage.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/StorSimpleCmdletHelpMessage.cs
@@ -106,7 +106,6 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
         public const string IPv6Prefix = "IPv6 Prefix for the net interface";
         public const string IsCloudEnabled = "Whether the net interface is cloud enabled/disabled";
         public const string IsIscsiEnabled = "Whether the net interface is iscsi enabled/disabled";
-        public const string PrimaryDnsServer = "Primary DNS server for the device.";
         public const string SecondaryDnsServer = "Secondary DNS server for the device.";
         public const string StorSimpleNetworkConfig = "A collection of network configs for interfaces on the device.";
         public const string TimeZone = "TimeZone for the device.";


### PR DESCRIPTION
Primary DNS server is not allowed to be set in the service and in the portal as well. Removing it from the cmdlet params