### PR TITLE
Bug fix: allow rename of entities

### DIFF
--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/BackupPolicy/SetAzureStorSimpleDeviceBackupPolicy.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/BackupPolicy/SetAzureStorSimpleDeviceBackupPolicy.cs
@@ -58,6 +58,10 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
         [Parameter(Position = 7, Mandatory = false, HelpMessage = StorSimpleCmdletHelpMessage.WaitTillComplete)]
         public SwitchParameter WaitForComplete { get; set; }
 
+        [Parameter(Position = 8, Mandatory = false, HelpMessage = StorSimpleCmdletHelpMessage.BackupPolicyNewName)]
+        [ValidateNotNullOrEmpty]
+        public string NewName { get; set; }
+
         private string deviceId = null;
         private List<BackupScheduleBase> schedulesToAdd = null;
         private List<BackupScheduleUpdateRequest> schedulesToUpdate = null;
@@ -74,7 +78,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                     return;
 
                 updateConfig.InstanceId = BackupPolicyId;
-                updateConfig.Name = BackupPolicyName;
+                updateConfig.Name = (NewName != null ? NewName : BackupPolicyName);
                 updateConfig.IsPolicyRenamed = true;
                 updateConfig.BackupSchedulesToBeAdded = schedulesToAdd;
                 updateConfig.BackupSchedulesToBeUpdated = schedulesToUpdate;

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/ServiceConfig/SetAzureStorSimpleAccessControlRecord.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/ServiceConfig/SetAzureStorSimpleAccessControlRecord.cs
@@ -71,7 +71,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                                 GlobalId = existingAcr.GlobalId,
                                 InitiatorName = IQNInitiatorName,
                                 InstanceId = existingAcr.InstanceId,
-                                Name = (NewName != null ? NewName : existingAcr.Name),
+                                Name = (!string.IsNullOrWhiteSpace(NewName) ? NewName : existingAcr.Name),
                                 VolumeCount = existingAcr.VolumeCount
                             },
                         }

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/ServiceConfig/SetAzureStorSimpleAccessControlRecord.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/ServiceConfig/SetAzureStorSimpleAccessControlRecord.cs
@@ -41,6 +41,10 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
         [Parameter(Position = 2, Mandatory = false, HelpMessage = StorSimpleCmdletHelpMessage.WaitTillComplete)]
         public SwitchParameter WaitForComplete { get; set; }
 
+        [Parameter(Position = 3, Mandatory = false, HelpMessage = StorSimpleCmdletHelpMessage.ACRNewName)]
+        [ValidateNotNullOrEmpty]
+        public string NewName { get; set; }
+
         public override void ExecuteCmdlet()
         {
             try
@@ -67,7 +71,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                                 GlobalId = existingAcr.GlobalId,
                                 InitiatorName = IQNInitiatorName,
                                 InstanceId = existingAcr.InstanceId,
-                                Name = existingAcr.Name,
+                                Name = (NewName != null ? NewName : existingAcr.Name),
                                 VolumeCount = existingAcr.VolumeCount
                             },
                         }

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Volume/SetAzureStorSimpleDeviceVolume.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Volume/SetAzureStorSimpleDeviceVolume.cs
@@ -54,6 +54,10 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
         [Parameter(Position = 6, Mandatory = false, HelpMessage = StorSimpleCmdletHelpMessage.WaitTillComplete)]
         public SwitchParameter WaitForComplete { get; set; }
 
+        [Parameter(Position = 7, Mandatory = false, HelpMessage = StorSimpleCmdletHelpMessage.VolumeNewName)]
+        [ValidateNotNullOrEmpty]
+        public string NewName { get; set; }
+
         public override void ExecuteCmdlet()
         {
             try
@@ -89,6 +93,10 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                 if (AccessControlRecords != null)
                 {
                     diskDetails.AcrList = AccessControlRecords;
+                }
+                if (NewName != null)
+                {
+                    diskDetails.Name = VolumeName = NewName;
                 }
 
                 if (WaitForComplete.IsPresent)

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Volume/SetAzureStorSimpleDeviceVolume.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Volume/SetAzureStorSimpleDeviceVolume.cs
@@ -94,16 +94,17 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                 {
                     diskDetails.AcrList = AccessControlRecords;
                 }
-                if (NewName != null)
+
+                if (!string.IsNullOrWhiteSpace(NewName))
                 {
-                    diskDetails.Name = VolumeName = NewName;
+                    diskDetails.Name = NewName;
                 }
 
                 if (WaitForComplete.IsPresent)
                 {
                     var taskstatus = StorSimpleClient.UpdateVolume(deviceId, diskDetails.InstanceId, diskDetails);
                     HandleSyncTaskResponse(taskstatus, "update");
-                    var updatedVolume = StorSimpleClient.GetVolumeByName(deviceId, VolumeName);
+                    var updatedVolume = StorSimpleClient.GetVolumeByName(deviceId, diskDetails.Name);
                     WriteObject(updatedVolume.VirtualDiskInfo);
                 }
                 else

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/StorSimpleCmdletHelpMessage.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/StorSimpleCmdletHelpMessage.cs
@@ -18,6 +18,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
     internal static class StorSimpleCmdletHelpMessage
     {
         public const string ACRName = "The access control record name.";
+        public const string ACRNewName = "The new name desired for the access control record";
         public const string ACRObject = "The access control record object.";
         public const string DataContainerBandwidth = "The data container bandwidth rate.";
         public const string DataContainerEncryptionEnabled = "Flag to encrypt the data container.";
@@ -46,6 +47,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
         public const string VolumeName = "The volume name.";
         public const string VolumeOnline = "Is the volume online";
         public const string VolumeSize = "The size of volume in bytes.";
+        public const string VolumeNewName = "The new name desired for the volume";
         public const string WaitTillComplete = "Wait till the async operation completes.";
         public const string BackupPolicyName = "Name of the Backup policy that you wish to retrieve. Skip this parameter to get all policies";
         public const string BackupIdToDelete = "InstanceId of the Backup that needs to be deleted";
@@ -78,6 +80,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
         public const string BackupScheduleBaseObjsToAdd = "List of BackupScheduleBase objects to be added to the policy";
         public const string BackupScheduleBaseObjsToUpdate = "List of BackupScheduleUpdateRequest objects to be updated";
         public const string BackupScheduleBaseObjsToDelete = "List of Instance Id of BackupSchedule objects to be deleted";
+        public const string BackupPolicyNewName = "The new name desired for the backup policy";
         public const string VolumeObjsToUpdate = "List of VolumeIds to be updated";
         public const string ResourceName = "Name of the resource which needs to be retrieved";
         public const string SourceDeviceId = "The device identifier of the source device";

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/StorSimpleCmdletHelpMessage.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/StorSimpleCmdletHelpMessage.cs
@@ -18,7 +18,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
     internal static class StorSimpleCmdletHelpMessage
     {
         public const string ACRName = "The access control record name.";
-        public const string ACRNewName = "The new name desired for the access control record";
+        public const string ACRNewName = "The new name for the access control record";
         public const string ACRObject = "The access control record object.";
         public const string DataContainerBandwidth = "The data container bandwidth rate.";
         public const string DataContainerEncryptionEnabled = "Flag to encrypt the data container.";
@@ -47,7 +47,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
         public const string VolumeName = "The volume name.";
         public const string VolumeOnline = "Is the volume online";
         public const string VolumeSize = "The size of volume in bytes.";
-        public const string VolumeNewName = "The new name desired for the volume";
+        public const string VolumeNewName = "The new name for the volume";
         public const string WaitTillComplete = "Wait till the async operation completes.";
         public const string BackupPolicyName = "Name of the Backup policy that you wish to retrieve. Skip this parameter to get all policies";
         public const string BackupIdToDelete = "InstanceId of the Backup that needs to be deleted";
@@ -80,7 +80,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
         public const string BackupScheduleBaseObjsToAdd = "List of BackupScheduleBase objects to be added to the policy";
         public const string BackupScheduleBaseObjsToUpdate = "List of BackupScheduleUpdateRequest objects to be updated";
         public const string BackupScheduleBaseObjsToDelete = "List of Instance Id of BackupSchedule objects to be deleted";
-        public const string BackupPolicyNewName = "The new name desired for the backup policy";
+        public const string BackupPolicyNewName = "The new name for the backup policy";
         public const string VolumeObjsToUpdate = "List of VolumeIds to be updated";
         public const string ResourceName = "Name of the resource which needs to be retrieved";
         public const string SourceDeviceId = "The device identifier of the source device";


### PR DESCRIPTION
Bug #1255726: StorSimple OneSDK does not support rename
Changes: Added 'NewName' parameter to Set cmdlets of ACR, Volume and Backup Policy