### PR TITLE
Onesdk p2 sumanths

### DIFF
--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Failover/GetAzureStorSimpleFailoverVolumeContainers.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Failover/GetAzureStorSimpleFailoverVolumeContainers.cs
@@ -22,8 +22,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
 {
 
 
-    [Cmdlet(VerbsCommon.Get, "AzureStorSimpleFailoverVolumeContainers", DefaultParameterSetName = StorSimpleCmdletParameterSet.Empty), 
-        OutputType(typeof(IList<DataContainerGroup>))]
+    [Cmdlet(VerbsCommon.Get, "AzureStorSimpleFailoverVolumeContainers"), OutputType(typeof(IList<DataContainerGroup>))]
     public class GetAzureStorSimpleFailoverVolumeContainers : StorSimpleCmdletBase
     {
         [Parameter(Position = 0, Mandatory = true, ParameterSetName = StorSimpleCmdletParameterSet.IdentifyById, HelpMessage = StorSimpleCmdletHelpMessage.DeviceId)]
@@ -43,7 +42,14 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                 switch(ParameterSetName)
                 {
                     case StorSimpleCmdletParameterSet.IdentifyById:
-                        deviceid = DeviceId;
+                        if (StorSimpleClient.IsValidDeviceId(DeviceId))
+                        {
+                            deviceid = DeviceId;
+                        }
+                        else
+                        {
+                            WriteVerbose(string.Format(Resources.NoDeviceFoundWithGivenIdInResourceMessage, StorSimpleContext.ResourceName, DeviceId));
+                        }
                         break;
                     case StorSimpleCmdletParameterSet.IdentifyByName:
                         deviceid = StorSimpleClient.GetDeviceId(DeviceName);

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Volume/RemoveAzureStorSimpleDeviceVolume .cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Volume/RemoveAzureStorSimpleDeviceVolume .cs
@@ -31,7 +31,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
         [ValidateNotNullOrEmpty]
         public string VolumeName { get; set; }
 
-        [Parameter(Position = 1, Mandatory = true, ParameterSetName = StorSimpleCmdletParameterSet.IdentifyByObject, ValueFromPipeline = true, HelpMessage = StorSimpleCmdletHelpMessage.VolumeId)]
+        [Parameter(Position = 1, Mandatory = true, ParameterSetName = StorSimpleCmdletParameterSet.IdentifyByObject, ValueFromPipeline = true, HelpMessage = StorSimpleCmdletHelpMessage.VolumeObject)]
         [ValidateNotNullOrEmpty]
         public VirtualDisk Volume { get; set; }
 
@@ -68,7 +68,7 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                                           break;
                                       case StorSimpleCmdletParameterSet.IdentifyByName:
                                           var volumeInfo = StorSimpleClient.GetVolumeByName(deviceid, VolumeName);
-                                          if (volumeInfo == null)
+                                          if (volumeInfo == null || volumeInfo.VirtualDiskInfo == null || volumeInfo.VirtualDiskInfo.InstanceId == null)
                                           {
                                               WriteVerbose(Resources.NotFoundMessageVirtualDisk);
                                               return;

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Volume/SetAzureStorSimpleDeviceVolume.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/Cmdlets/Volume/SetAzureStorSimpleDeviceVolume.cs
@@ -28,9 +28,13 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
         public string DeviceName { get; set; }
 
         [Alias("Name")]
-        [Parameter(Position = 1, Mandatory = true, HelpMessage = StorSimpleCmdletHelpMessage.VolumeName)]
+        [Parameter(Position = 1, Mandatory = true, ParameterSetName = StorSimpleCmdletParameterSet.IdentifyByName, HelpMessage = StorSimpleCmdletHelpMessage.VolumeName)]
         [ValidateNotNullOrEmpty]
         public string VolumeName { get; set; }
+
+        [Parameter(Position = 1, Mandatory = true, ParameterSetName = StorSimpleCmdletParameterSet.IdentifyByObject, ValueFromPipeline = true, HelpMessage = StorSimpleCmdletHelpMessage.VolumeObject)]
+        [ValidateNotNullOrEmpty]
+        public VirtualDisk Volume { get; set; }
 
         [Parameter(Position = 2, Mandatory = false, HelpMessage = StorSimpleCmdletHelpMessage.VolumeOnline)]
         [ValidateNotNullOrEmpty]
@@ -70,7 +74,20 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple.Cmdlets
                     return;
                 }
 
-                VirtualDisk diskDetails = StorSimpleClient.GetVolumeByName(deviceId, VolumeName).VirtualDiskInfo;
+                VirtualDisk diskDetails = null;
+
+                switch (ParameterSetName)
+                {
+                    case StorSimpleCmdletParameterSet.IdentifyByObject:
+                        diskDetails = Volume;
+                        break;
+                    case StorSimpleCmdletParameterSet.IdentifyByName:
+                        diskDetails = StorSimpleClient.GetVolumeByName(deviceId, VolumeName).VirtualDiskInfo;
+                        break;
+                    default:
+                        break;
+                }
+
                 if (diskDetails == null)
                 {
                     WriteVerbose(Resources.NotFoundMessageVirtualDisk);

--- a/src/ServiceManagement/StorSimple/Commands.StorSimple/ServiceClients/StorSimpleDevicesClient.cs
+++ b/src/ServiceManagement/StorSimple/Commands.StorSimple/ServiceClients/StorSimpleDevicesClient.cs
@@ -74,6 +74,21 @@ namespace Microsoft.WindowsAzure.Commands.StorSimple
             return taskStatusInfo;
         }
 
+        public bool IsValidDeviceId(string deviceId)
+        {
+            if (string.IsNullOrWhiteSpace(deviceId)) throw new ArgumentNullException("deviceId");
+            var deviceInfos = GetAllDevices();
+            foreach (var deviceInfo in deviceInfos)
+            {
+                if (deviceInfo.DeviceId.Equals(deviceId, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public string GetDeviceId(string deviceToUse)
         {
             if (deviceToUse == null) throw new ArgumentNullException("deviceToUse");


### PR DESCRIPTION
Bug fixes - 
#2090691:[OneSDK] Get-ASSFailoverVolumeContainers: Passing a non-existent device id should complain about device not being found
#2090702:[OneSDK] Get-ASSFailoverVolumeContainers: When none of the params are passed, the cmdlet silently does nothing.
#2090782:[OneSDK] Not Able to Pipe-in the Volumes to Set-AzureStorSimpleDeviceVolume
#2143010:Remove-ASSDeviceVolume throws invalid error when volume name doesn't match
